### PR TITLE
blocks, include, inherits and caching for partials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ var ejs = require('ejs')
  *
  */
 
-module.exports = function(path, options, fn){
+var renderFile = module.exports = function(path, options, fn){
 
   options.locals.block = block.bind(options);
   options.locals.inherits = inherits.bind(options);
@@ -40,7 +40,7 @@ module.exports = function(path, options, fn){
 
   ejs.renderFile(path, options, function(err, html) {
 
-    var layout = options.layout || (options.locals && options.locals._layout);
+    var layout = (options.locals && options.locals._layout) || options.layout;
 
     // recurse and use this layout as `body` in the parent
     if (layout) {
@@ -67,7 +67,7 @@ module.exports = function(path, options, fn){
       // find layout path relative to current template
       var file = join(dirname(path), layout);
       options.locals.body = html;
-      ejs.renderFile(file, options, fn);
+      renderFile(file, options, fn);
     } else {
       fn(null, html);
     }

--- a/index.js
+++ b/index.js
@@ -42,13 +42,13 @@ module.exports = function(path, options, fn){
 
     var layout = options.layout || (options.locals && options.locals._layout);
 
-    if (layout === true) {
-      // default layout
-      layout = 'layout.ejs';
-    }
-
     // recurse and use this layout as `body` in the parent
     if (layout) {
+
+      if (layout === true) {
+        // default layout
+        layout = 'layout.ejs';
+      }
 
       if (extname(layout) != '.ejs') {
         // default extension
@@ -118,7 +118,14 @@ function resolveObjectName(view){
  *   - any `<root>/<name>`
  *   - partial `<root>/_<name>`
  *
- * @param {View} view
+ * Options:
+ *
+ *   - `cache` store the resolved path for the view, to avoid disk I/O
+ *
+ * @param {String} room, base path for searching for templates
+ * @param {String} view, name of the partial to lookup (without path)
+ * @param {String} ext, type of template to find, with '.'
+ * @param {Object} options, for `options.cache` behavior
  * @return {String}
  * @api private
  */
@@ -171,7 +178,7 @@ function lookup(root, view, ext, options){
  * @param  {String} view
  * @param  {Object|Array} options, collection or object
  * @return {String}
- * @api public
+ * @api private
  */
 
 function partial(view, options){
@@ -297,22 +304,20 @@ function partial(view, options){
  * (`layout` is bound to res in the middleware, so this == res)
  *
  * @param  {String} view
- * @api public
+ * @api private
  */
 function inherits(view){
   this.locals._layout = view;
 }
 
 /**
- * Apply the given `options` to the given `view` to be included
- * in the current template.
+ * Apply the current `options` to the given `view` to be included
+ * in the current template at call time.
  *
- * `options` are bound in the middleware, you just call include())
- * This function is bound to res in the middleware, so this == res
+ * `options` are bound in the middleware, you just call `include('myview')`
  *
- * @param  {Object} options
  * @param  {String} view
- * @api public
+ * @api private
  */
 function include(view) {
   return partial.apply(this, [ view ]);
@@ -337,6 +342,18 @@ Block.prototype = {
   }
 };
 
+/**
+ * Return the block with the given name, create it if necessary.
+ * Optionally append the given html to the block.
+ *
+ * The returned Block can append, prepend or replace the block,
+ * as well as render it when included in a parent template.
+ *
+ * @param  {String} name
+ * @param  {String} html
+ * @return {Block}
+ * @api private
+ */
 function block(name, html) {
   var blocks = this.locals._blocks || (this.locals._blocks = {});
   if (!blocks[name]) {

--- a/test/fixtures/blocks-layout.ejs
+++ b/test/fixtures/blocks-layout.ejs
@@ -1,0 +1,1 @@
+<%-block('sidebar')%><%-body%><%-block('footer')%>

--- a/test/fixtures/inherit-child-blocks.ejs
+++ b/test/fixtures/inherit-child-blocks.ejs
@@ -1,0 +1,1 @@
+<%inherits('inherit-parent-blocks')%><%- body %><b>I am child content.</b><%script('c.js')%><%stylesheet('c.css')%>

--- a/test/fixtures/inherit-child.ejs
+++ b/test/fixtures/inherit-child.ejs
@@ -1,0 +1,1 @@
+<%inherits('inherit-parent')%><%- body %><b>I am child content.</b>

--- a/test/fixtures/inherit-grandchild-blocks.ejs
+++ b/test/fixtures/inherit-grandchild-blocks.ejs
@@ -1,0 +1,1 @@
+<%inherits('inherit-child-blocks')%><i>I am grandchild content.</i><%script('gc.js')%><%stylesheet('gc.css')%>

--- a/test/fixtures/inherit-grandchild.ejs
+++ b/test/fixtures/inherit-grandchild.ejs
@@ -1,0 +1,1 @@
+<%inherits('inherit-child')%><i>I am grandchild content.</i>

--- a/test/fixtures/inherit-parent-blocks.ejs
+++ b/test/fixtures/inherit-parent-blocks.ejs
@@ -1,0 +1,1 @@
+<html><head><title>express-partials</title><%-scripts%><%-stylesheets%></head><body><%- body %><u>I am parent content.</u></body></html>

--- a/test/fixtures/inherit-parent.ejs
+++ b/test/fixtures/inherit-parent.ejs
@@ -1,0 +1,1 @@
+<html><head><title>express-partials</title></head><body><%- body %><u>I am parent content.</u></body></html>

--- a/test/fixtures/with-blocks.ejs
+++ b/test/fixtures/with-blocks.ejs
@@ -1,0 +1,1 @@
+<% block('footer', '© 2012') %><% inherits('blocks-layout') %><p>What's up?</p><% block('sidebar', '<li><a href="hello.html">'+hello+'</a></li>') %>

--- a/test/fixtures/with-include.ejs
+++ b/test/fixtures/with-include.ejs
@@ -1,0 +1,1 @@
+<html><head><title>express-partials</title></head><body><%-include('locals')%></body></html>

--- a/test/fixtures/with-layout.ejs
+++ b/test/fixtures/with-layout.ejs
@@ -1,0 +1,1 @@
+<%inherits('layout')%><h1>Index</h1>

--- a/test/test.partials.js
+++ b/test/test.partials.js
@@ -66,6 +66,10 @@ app.get('/with-blocks',function(req,res,next){
   res.render('with-blocks.ejs',{layout:false});
 })
 
+app.get('/deep-inheritance',function(req,res,next){
+  res.render('inherit-grandchild.ejs');
+})
+
 describe('app',function(){
 
   describe('GET /',function(){
@@ -219,6 +223,18 @@ describe('app',function(){
         .end(function(res){
           res.should.have.status(200);
           res.body.should.equal('<li><a href="hello.html">there</a></li><p>What\'s up?</p>© 2012');
+          done();
+        })
+    })
+  })
+
+  describe('GET /deep-inheritance',function(){
+    it('should recurse and keep applying layouts until done',function(done){
+      request(app)
+        .get('/deep-inheritance')
+        .end(function(res){
+          res.should.have.status(200);
+          res.body.should.equal('<html><head><title>express-partials</title></head><body><i>I am grandchild content.</i><b>I am child content.</b><u>I am parent content.</u></body></html>');
           done();
         })
     })

--- a/test/test.partials.js
+++ b/test/test.partials.js
@@ -42,7 +42,28 @@ app.get('/collection/thing',function(req,res,next){
   res.render('collection.ejs',{name: 'thing', list:[{name:'one'},{name:'two'}]})
 })
 
+app.get('/with-layout',function(req,res,next){
+  res.render('with-layout.ejs');
+})
+
+app.get('/with-layout-override',function(req,res,next){
+  res.render('with-layout.ejs',{layout:false})
+})
+
+app.get('/with-include-here',function(req,res,next){
+  res.render('with-include.ejs',{layout:false, hello:'here'});
+})
+
+app.get('/with-include-there',function(req,res,next){
+  res.render('with-include.ejs',{layout:false});
+})
+
+app.get('/with-blocks',function(req,res,next){
+  res.render('with-blocks.ejs',{layout:false});
+})
+
 describe('app',function(){
+
   describe('GET /',function(){
     it('should render with default layout.ejs',function(done){
       request(app)
@@ -138,5 +159,65 @@ describe('app',function(){
         })
     })
   })
-  
+
+  describe('GET /with-layout',function(){
+    it('should use layout.ejs when rendering with-layout.ejs',function(done){
+      request(app)
+        .get('/with-layout')
+        .end(function(res){
+          res.should.have.status(200);
+          res.body.should.equal('<html><head><title>express-partials</title></head><body><h1>Index</h1></body></html>');
+          done();
+        })
+    })
+  })
+
+  describe('GET /with-layout-override',function(){
+    it('should use layout.ejs when rendering with-layout.ejs, even if layout=false in options',function(done){
+      request(app)
+        .get('/with-layout-override')
+        .end(function(res){
+          res.should.have.status(200);
+          res.body.should.equal('<html><head><title>express-partials</title></head><body><h1>Index</h1></body></html>');
+          done();
+        })
+    })
+  })
+
+  describe('GET /with-include-here',function(){
+    it('should include and interpolate locals.ejs when rendering with-include.ejs',function(done){
+      request(app)
+        .get('/with-include-here')
+        .end(function(res){
+          res.should.have.status(200);
+          res.body.should.equal('<html><head><title>express-partials</title></head><body><h1>here</h1></body></html>');
+          done();
+        })
+    })
+  })
+
+  describe('GET /with-include-there',function(){
+    it('should include and interpolate locals.ejs when rendering with-include.ejs',function(done){
+      request(app)
+        .get('/with-include-there')
+        .end(function(res){
+          res.should.have.status(200);
+          res.body.should.equal('<html><head><title>express-partials</title></head><body><h1>there</h1></body></html>');
+          done();
+        })
+    })
+  })
+
+  describe('GET /with-blocks',function(){
+    it('should arrange blocks into layout-with-blocks.ejs when rendering with-blocks.ejs',function(done){
+      request(app)
+        .get('/with-blocks')
+        .end(function(res){
+          res.should.have.status(200);
+          res.body.should.equal('<li><a href="hello.html">there</a></li><p>What\'s up?</p>© 2012');
+          done();
+        })
+    })
+  })
+
 })

--- a/test/test.partials.js
+++ b/test/test.partials.js
@@ -70,6 +70,10 @@ app.get('/deep-inheritance',function(req,res,next){
   res.render('inherit-grandchild.ejs');
 })
 
+app.get('/deep-inheritance-blocks',function(req,res,next){
+  res.render('inherit-grandchild-blocks.ejs');
+})
+
 describe('app',function(){
 
   describe('GET /',function(){
@@ -235,6 +239,18 @@ describe('app',function(){
         .end(function(res){
           res.should.have.status(200);
           res.body.should.equal('<html><head><title>express-partials</title></head><body><i>I am grandchild content.</i><b>I am child content.</b><u>I am parent content.</u></body></html>');
+          done();
+        })
+    })
+  })
+
+  describe('GET /deep-inheritance-blocks',function(){
+    it('should recurse and keep applying blocks to layouts until done',function(done){
+      request(app)
+        .get('/deep-inheritance-blocks')
+        .end(function(res){
+          res.should.have.status(200);
+          res.body.should.equal('<html><head><title>express-partials</title><script src="gc.js"></script>\n<script src="c.js"></script><link rel="stylesheet" href="gc.css" />\n<link rel="stylesheet" href="c.css" /></head><body><i>I am grandchild content.</i><b>I am child content.</b><u>I am parent content.</u></body></html>');
           done();
         })
     })

--- a/test/test.partials.js
+++ b/test/test.partials.js
@@ -3,8 +3,12 @@ var express = require('express')
   , partials = require('../');
 
 var app = express();
-app.use(partials());
-app.set('views',__dirname + '/fixtures')
+// app.use(partials());
+app.set('views',__dirname + '/fixtures');
+app.engine('ejs', partials);
+app.locals({
+  layout: true
+})
 
 app.locals.use(function(req,res){
   app.locals.hello = 'there';


### PR DESCRIPTION
I've attempted to implement a few features but it required a bit of rearranging to do so... I've opened this pull request to get feedback, I'll follow up with some tweaks to the README etc if reception is generally positive.

These could also serve as a prototype for fixes to https://github.com/visionmedia/ejs/issues/35 so hopefully @visionmedia spots this too.
### `block(name,html)`

First, I've implemented a simple `blocks` local function that allows a layout to receive scripts, stylesheets etc from another template.

e.g. if you have this template in `stuff.ejs`:

``` html
<% block('sidebar', '<li><a href="foo.html">bar</a></li>') %>
<% block('sidebar', '<li><a href="baz.html">quux</a></li>') %>
<p>I'm the main content here!</p>
```

And this layout in `layout-blocks.ejs`:

``` html
<html>
<body>
<div id="main">
<%-body%>
</div>
<div id="sidebar">
<%-block('sidebar')%>
</div>
</body>
</html>
```

Then when you do: `res.render('stuff.ejs', { layout: 'layout-blocks.ejs' })` you get:

``` html
<html>
<body>
<div id="main">
<p>I'm the main content here!</p>
</div>
<div id="sidebar">
<ul>
<li><a href="foo.html">bar</a></li>
<li><a href="baz.html">quux</a></li>
</ul>
</body>
</html>
```

I didn't want to get into the internals of ejs parsing so I didn't make a nicer way to use bigger blocks yet. I will probably adjust the output to match the syntax of https://github.com/aseemk/express-blocks (ie `blocks.sidebar` instead of `blocks('sidebar')`). That library also has nice helpers for stylesheets and scripts and was definitely an inspiration for this feature.

If I do a nicer way to append blocks it will probably be something like:

``` html
<%blocks('sidebar',%>
<li><a href="foo.html">bar</a></li>
<%)%>
```

Or maybe:

``` html
<%sidebar%>
<li><a href="foo.html">bar</a></li>
<%/sidebar%>
```

With `<%-sidebar%>` or `<%-blocks.sidebar%>`to include the results in a layout either way. I'm not sure though - probably worth a survey of rails, django, smarty etc. to see how it's done there?
### `inherits(view)`

This one is a bit simpler. I want to call it `layout` but for the moment that conflicts with the backwards-compatible flag for applying a layout via `res.render(..., { layout: 'foo' })`.

If you have this template in `child.ejs`:

``` html
<%inherits('parent')%>
<h1>I am from the child!</h1>
```

And this layout in `parent.ejs`:

``` html
<%-body%>
```

Then `res.render('child')` will produce:

``` html
<h1>I am from the child!</h1>
```

Even if `layout` is set to false in the render options... which I think is right. This is the way Express is going already (see https://github.com/visionmedia/express/wiki/Migrating-from-2.x-to-3.x) and the Jade template engine implements something similar already. I'm in favor of removing the `layout` flag and default layouts entirely and letting templates declare if they want a layout - what do you think? This will allow trivially renaming the `inherits(...)` function to `layout(...)` without needing to resort to hacking around with the options and locals objects, which are already a bit messy. I already switched layouts off by default, though the backwards compatible side of keeping them on is tempting of course.
### `include(view)`

Right now this is shorthand for `partial(view,options)` where options are the original options passed to the parent template. As I look at your implementation of `partial` now I wonder if that's the right thing. In the end I'd like this to support other view engines too, so you could include a block of markdown or whatever instead of just ejs.
### caching

The current master branch doesn't observe the `options.cache` setting... partly because I don't think it can see that setting while implemented as middleware. I've rearranged things so that the library is instead registered as a `view engine` for `ejs`. 

So instead of this:

``` javascript
var partials = require('express-partials');
app.use(partials());
```

You now do this:

``` javascript
var partials = require('express-partials');
app.engine('ejs', partials);
app.locals({
  layout: true
})
```

Another benefit to this is that views that don't use res.render don't pay the price of setting up the locals and applying the patches - not a big concern but it seems tidier.
### tests

Right now to test with caching enabled I run `NODE_ENV=production ./node_modules/mocha/bin/mocha -r should` - all tests are passing, but it would probably be worth writing some more, and possibly worth wiring up the test file to toggle process.env.NODE_ENV and do another pass with a new app instance. If anyone tries this and you find yourself adding more tests, watch out for new lines in your editor - it makes composing the precise expected html output quite tricky!

Hope this all makes sense and look forward to hearing your thoughts!
