### PR TITLE
Add support for other engines

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,6 +77,9 @@ module.exports = function(){
  */
 
 var register = function(ext,render) {
+  if(ext[0] !== '.') {
+    ext = '.' + ext;
+  }
   register[ext] = render;
 };
 
@@ -88,9 +91,12 @@ module.exports.register = register;
  */
 
 var renderer = function(ext) {
+  if(ext[0] !== '.') {
+    ext = '.' + ext;
+  }
   return register[ext] != null
     ? register[ext]
-    : register[ext] = require(ext).render;
+    : register[ext] = require(ext.slice(1)).render;
 };
 
 module.exports.renderer = renderer;

--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ module.exports = function(){
           options.body = body;
 
           // now render the layout
-          var ext = extname(name) || '.'+res.app.get('view engine');
+          var ext = extname(name) || '.'+(res.app.get('view engine') || 'ejs');
           _render(basename(layout,ext)+ext, options, fn);
         })
 
@@ -239,7 +239,7 @@ function partial(view, options){
 
   // find view
   var root = this.app.get('views') || process.cwd() + '/views'
-    , ext = extname(view) || '.' + this.app.get('view engine')
+    , ext = extname(view) || '.' + (this.app.get('view engine')||'ejs')
     , file = lookup(root, view, ext);
   
   // read view

--- a/package.json
+++ b/package.json
@@ -10,12 +10,13 @@
     "node": "~0.6.8"
   },
   "dependencies": {
-    "ejs": "*"
   },
   "devDependencies": {
     "express": "git://github.com/visionmedia/express.git",
     "mocha": "*",
-    "should": "*"
+    "should": "*",
+    "ejs": "*",
+    "jade": "*"
   },
   "scripts": {
     "test": "mocha -r should"

--- a/test/fixtures/index.j
+++ b/test/fixtures/index.j
@@ -1,0 +1,1 @@
+h2= 'Jade says hello ' + hello

--- a/test/fixtures/layout.j
+++ b/test/fixtures/layout.j
@@ -1,0 +1,5 @@
+html
+  head
+    title Jade layout
+  body
+    != body

--- a/test/test.partials.js
+++ b/test/test.partials.js
@@ -42,6 +42,16 @@ app.get('/collection/thing',function(req,res,next){
   res.render('collection.ejs',{name: 'thing', list:[{name:'one'},{name:'two'}]})
 })
 
+partials.register('.j',require('jade').render);
+app.get('/register/no-layout',function(req,res,next){
+  res.render('index.j',{hello:'world',layout:false})
+})
+
+app.engine('.j',require('jade').__express);
+app.get('/register',function(req,res,next){
+  res.render('index.j',{hello:'world'})
+})
+
 describe('app',function(){
   describe('GET /',function(){
     it('should render with default layout.ejs',function(done){
@@ -138,5 +148,29 @@ describe('app',function(){
         })
     })
   })
-  
+
+  describe('GET /register/no-layout',function(){
+    it('should render index.j as a Jade template',function(done){
+      request(app)
+        .get('/register/no-layout')
+        .end(function(res){
+          res.should.have.status(200);
+          res.body.should.equal('<h2>Jade says hello world</h2>');
+          done();
+        })
+    })
+  })
+
+  describe('GET /register',function(){
+    it('should render index.j as a Jade template with layout.j as Jade layout',function(done){
+      request(app)
+        .get('/register')
+        .end(function(res){
+          res.should.have.status(200);
+          res.body.should.equal('<html><head><title>Jade layout</title></head><body><h2>Jade says hello world</h2></body></html>');
+          done();
+        })
+    })
+  })
+
 })


### PR DESCRIPTION
Any engine that provides a synchronous `render()` function should work.
