### PR TITLE
Make `register` more flexible

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,9 @@ var path = require('path')
  *      , partials = require('express-partials')
  *      , app = express();
  *    app.use(partials());
+ *    // three ways to register a template engine:
+ *    partials.register('coffee','coffeekup');
+ *    partials.register('coffee',require('coffeekup'));
  *    partials.register('coffee',require('coffeekup').render);
  *    app.get('/',function(req,res,next){
  *      res.render('index.ejs') // renders layout.ejs with index.ejs as `body`.
@@ -74,13 +77,25 @@ module.exports = function(){
 /* Allow to register a specific rendering
  * function for a given extension.
  * (Similar to Express 2.x register() function.)
+ *
+ * The second argument might be:
+ *   a template module's name
+ *   a module with a `render` method
+ *   a synchronous `render` method
  */
 
 var register = function(ext,render) {
   if(ext[0] !== '.') {
     ext = '.' + ext;
   }
-  register[ext] = render;
+  if(typeof render === 'string') {
+    render = require(render);
+  }
+  if(render.render !== null) {
+    register[ext] = render.render;
+  } else {
+    register[ext] = render;
+  }
 };
 
 module.exports.register = register;

--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
     "mocha": "*",
     "should": "*",
     "ejs": "*",
-    "jade": "*"
+    "jade": "*",
+    "eco": "*",
+    "coffeecup": "*",
+    "consolidate": "*"
   },
   "scripts": {
     "test": "mocha -r should"

--- a/test/fixtures/index.coffeecup
+++ b/test/fixtures/index.coffeecup
@@ -1,0 +1,1 @@
+h2 "CoffeeCup says hello #{@hello}"

--- a/test/fixtures/index.eco
+++ b/test/fixtures/index.eco
@@ -1,0 +1,1 @@
+<h2>Eco says hello <%- @hello %></h2>

--- a/test/fixtures/layout.coffeecup
+++ b/test/fixtures/layout.coffeecup
@@ -1,0 +1,5 @@
+html ->
+  head ->
+    title 'CoffeeCup layout'
+  body ->
+    @body

--- a/test/fixtures/layout.eco
+++ b/test/fixtures/layout.eco
@@ -1,0 +1,1 @@
+<html><head><title>Eco layout</title></head><body><%- @body %></body></html>

--- a/test/test.partials.js
+++ b/test/test.partials.js
@@ -42,12 +42,11 @@ app.get('/collection/thing',function(req,res,next){
   res.render('collection.ejs',{name: 'thing', list:[{name:'one'},{name:'two'}]})
 })
 
-partials.register('.j',require('jade').render);
+app.engine('.j',require('jade').__express);
 app.get('/register/no-layout',function(req,res,next){
   res.render('index.j',{hello:'world',layout:false})
 })
 
-app.engine('.j',require('jade').__express);
 app.get('/register',function(req,res,next){
   res.render('index.j',{hello:'world'})
 })
@@ -149,25 +148,53 @@ describe('app',function(){
     })
   })
 
-  describe('GET /register/no-layout',function(){
-    it('should render index.j as a Jade template',function(done){
+  describe('GET /register',function(){
+    it('should render index.j as a Jade template with layout.j as Jade layout (register: function)',function(done){
+      partials.register('.j',require('jade').render);
       request(app)
-        .get('/register/no-layout')
+        .get('/register')
         .end(function(res){
           res.should.have.status(200);
-          res.body.should.equal('<h2>Jade says hello world</h2>');
+          res.body.should.equal('<html><head><title>Jade layout</title></head><body><h2>Jade says hello world</h2></body></html>');
           done();
         })
     })
   })
 
   describe('GET /register',function(){
-    it('should render index.j as a Jade template with layout.j as Jade layout',function(done){
+    it('should render index.j as a Jade template with layout.j as Jade layout (register: module)',function(done){
+      partials.register('.j',require('jade'));
       request(app)
         .get('/register')
         .end(function(res){
           res.should.have.status(200);
           res.body.should.equal('<html><head><title>Jade layout</title></head><body><h2>Jade says hello world</h2></body></html>');
+          done();
+        })
+    })
+  })
+
+  describe('GET /register',function(){
+    it('should render index.j as a Jade template with layout.j as Jade layout (register: name)',function(done){
+      partials.register('.j','jade');
+      request(app)
+        .get('/register')
+        .end(function(res){
+          res.should.have.status(200);
+          res.body.should.equal('<html><head><title>Jade layout</title></head><body><h2>Jade says hello world</h2></body></html>');
+          done();
+        })
+    })
+  })
+
+  describe('GET /register/no-layout',function(){
+    it('should render index.j as a Jade template (using only Express 3.x)',function(done){
+      partials.register('.j',{});
+      request(app)
+        .get('/register/no-layout')
+        .end(function(res){
+          res.should.have.status(200);
+          res.body.should.equal('<h2>Jade says hello world</h2>');
           done();
         })
     })


### PR DESCRIPTION
I didn't figure out we could have `register` use different types of arguments until I tried to use it for real. :(

This makes `register` incrementally a little bit more clever about its second argument. It now accepts a render function (same as previously), a template module (or some object with a `render` member), or a template module name.

Updated tests are provided.
