### PR TITLE
Handle literal paths for partials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+node_modules/
+*~

--- a/index.js
+++ b/index.js
@@ -174,6 +174,8 @@ function resolveObjectName(view){
 function lookup(root, view, ext){
   var name = resolveObjectName(view);
 
+  if(exists(view)) return view;
+
   // Try _ prefix ex: ./views/_<name>.jade
   // taking precedence over the direct path
   view = resolve(root,'_'+name+ext)

--- a/test/fixtures/partial-from-fn.ejs
+++ b/test/fixtures/partial-from-fn.ejs
@@ -1,0 +1,1 @@
+<h1>partial-from-absolute-path:<%- partial(get_template_path()) %></h1>

--- a/test/test.partials.js
+++ b/test/test.partials.js
@@ -6,8 +6,10 @@ var app = express();
 app.use(partials());
 app.set('views',__dirname + '/fixtures')
 
-app.locals.use(function(req,res){
-  app.locals.hello = 'there';
+app.use(function(req,res,next){
+  res.locals.hello = 'there';
+  res.locals.get_template_path = function() { return __dirname + '/fixtures/subdir/index.ejs'; };
+  next();
 })
 
 app.get('/',function(req,res,next){
@@ -48,6 +50,10 @@ app.get('/subdir',function(req,res,next){
 
 app.get('/subdir-explicit',function(req,res,next){
   res.render('subdir/index.ejs', {layout: 'subdir/layout.ejs', list:[{name:'one'},{name:'two'}]})
+})
+
+app.get('/absolute-path',function(req,res,next){
+  res.render('partial-from-fn.ejs', {})
 })
 
 
@@ -274,6 +280,18 @@ describe('app',function(){
         .end(function(res) {
           res.should.have.status(200);
           res.body.should.equal('<html><title>subdir layout</title><body><h2>Hello World</h2></body></html>');
+          done();
+        })
+    })
+  })
+
+  describe('GET /absolute-path',function() {
+    it('should render index.ejs with layout.ejs layout and a partial specified by an absolute path returned by a function', function(done) {
+      request(app)
+        .get('/absolute-path')
+        .end(function(res) {
+          res.should.have.status(200);
+          res.body.should.equal('<html><head><title>express-partials</title></head><body><h1>partial-from-absolute-path:<h2>Hello World</h2></h1></body></html>');
           done();
         })
     })


### PR DESCRIPTION
I have a complex views layout so I end up specifying partial views directly for mixins - this helps there, no harm otherwise.
