### PR TITLE
Supporting paths with backslash (windows)

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,7 +145,7 @@ var cache = {};
 
 function resolveObjectName(view){
   return cache[view] || (cache[view] = view
-    .split('/')
+    .split(path.sep || '/')
     .slice(-1)[0]
     .split('.')[0]
     .replace(/^_/, '')


### PR DESCRIPTION
When running on windows path.join("xpto", "something") will return "xpto\something" and resolveObjectName() won't work. This can be fixed by simply calling the split() like this: split(path.sep || '/')
