### PR TITLE
Making possible for tests to run on windows

### DIFF
--- a/test/support/http.js
+++ b/test/support/http.js
@@ -5,7 +5,8 @@
 
 var EventEmitter = require('events').EventEmitter
   , methods = require('methods')
-  , http = require('http');
+  , http = require('http')
+  , onwindows = require('os').type() === 'Windows_NT';
 
 module.exports = request;
 
@@ -20,7 +21,7 @@ function Request(app) {
   this.app = app;
   if (!this.server) {
     this.server = http.Server(app);
-    this.server.listen(0, '127.0.0.1', function(){
+    this.server.listen(0, onwindows === true ? '127.0.0.1' : '0.0.0.0', function(){
       self.addr = self.server.address();
       self.listening = true;
     });

--- a/test/support/http.js
+++ b/test/support/http.js
@@ -20,7 +20,7 @@ function Request(app) {
   this.app = app;
   if (!this.server) {
     this.server = http.Server(app);
-    this.server.listen(0, function(){
+    this.server.listen(0, '127.0.0.1', function(){
       self.addr = self.server.address();
       self.listening = true;
     });


### PR DESCRIPTION
Before all tests used to throw the error EADDRNOTAVAIL.

This can be fixed by simply pass '127.0.0.1' address to the http server.
