### PR TITLE
Fix `locals` within sub-partials issue #2

### DIFF
--- a/index.js
+++ b/index.js
@@ -266,6 +266,10 @@ function partial(view, options){
   for(var k in this.app.locals)
     options[k] = options[k] || this.app.locals[k];
 
+  // merge locals, which as set using app.use(function(...){ res.locals = X; }) 
+  for(var k in this.req.res.locals)
+    options[k] = options[k] || this.req.res.locals[k];
+
   // let partials render partials
   options.partial = partial.bind(this);
 


### PR DESCRIPTION
This fix is actually similar with the [#22](https://github.com/publicclass/express-partials/issues/22) issue. 
I am setting the locals like this: 

<code>
app.configure(function() {
...
    app.use(function(req, res, next){
        res.locals.logged_user = req.user;
        res.locals.config = config;
        next();
    })
...
})
</code>
In regular views I can access the locals objects. But If I try to acess, let's say, `logged_user` object inside a partial which is included into another partial - I get an error. 

So this commit fixes the issue. 
