### PR TITLE
Added support for single option parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -252,8 +252,11 @@ function partial(view, options){
 
   // parse options
   if( options ){
-    // collection
-    if( options.collection ){
+    // if single option, else if collection
+  	if ( !(options instanceof Array) ) {
+  	  collection = [ options ];
+  	  options = {};
+  	} else if( options.collection ){
       collection = options.collection;
       delete options.collection;
     } else if( 'length' in options ){


### PR DESCRIPTION
I added a change that allows single options for partials (not just an array!). Like this:

partial('something', 'this string will be available as something');

partial('something', { title: 'this will be something.title', desc: 'this will be something.desc' } );
