### PR TITLE
Added locals back to options for access within partials.

### DIFF
--- a/index.js
+++ b/index.js
@@ -318,6 +318,7 @@ function partial(view, options){
         // merge(options, object);
       }
     }
+    options.locals = locals
     return renderer(ext)(source, options);
   }
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "mocha": "*",
     "supertest": "*",
     "ejs": "*",
+    "hamljs": "*",
     "jade": "*",
     "eco": "*",
     "coffeecup": "*",

--- a/test/fixtures/locals/app.js
+++ b/test/fixtures/locals/app.js
@@ -1,0 +1,20 @@
+var express = require('express')
+  , engines = require('consolidate')
+  , partials = require('../../../')
+  , app = module.exports = express();
+
+app.engine('haml', engines.haml);
+app.use(partials());
+partials.register('.haml','hamljs'); 
+
+app.use(partials());
+app.set('views',__dirname)
+
+app.use(function(req,res,next){
+  app.set('view engine', 'haml');
+  next()
+})
+
+app.get('/',function(req,res,next){
+  res.render('index', {favourite_number: 48, favourite_colour: "blue"})
+})

--- a/test/fixtures/locals/details.haml
+++ b/test/fixtures/locals/details.haml
@@ -1,0 +1,1 @@
+.inner= favourite_colour

--- a/test/fixtures/locals/index.haml
+++ b/test/fixtures/locals/index.haml
@@ -1,0 +1,4 @@
+
+.outer= favourite_number
+.outer= favourite_colour
+!= partial("details",{ locals: { favourite_colour: "yellow"} })

--- a/test/test.partials.haml-locals.js
+++ b/test/test.partials.haml-locals.js
@@ -1,0 +1,14 @@
+var app = require('./fixtures/locals/app')
+  , request = require('supertest');
+
+describe('app',function(){
+  describe('GET /',function(){
+    it('should propagate local variables',function(done){
+      request(app)
+        .get('/')
+        .expect(200)
+        .expect('<div class="outer">48</div>\n<div class="outer">blue</div>\n<div class="inner">yellow</div>')
+        .end(done);
+    })
+  })
+})


### PR DESCRIPTION
I am new to node.js -- so I am not sure if this is an issue with haml.js, or with express-partials, but in essence I was not able to successfully pass local variables into my haml partials.

So, I added the "locals" to the options directly and things worked like a charm (see npm spec showing the issue I was trying to accomplish.
