### PR TITLE
Add option to specify global default layout path

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,8 +46,11 @@ module.exports = function(){
       var layout = options && options.layout;
 
       // default layout
-      if( layout === true || layout === undefined )
-        layout = 'layout';
+      if( layout === true || layout === undefined ) {
+        // Try to find default layout in view options, if not found, seek for 'layout'
+        var viewOptions = res.app.get('view options');
+        layout = viewOptions && viewOptions.defaultLayout || 'layout';
+      }
       
       // layout
       if( layout ){


### PR DESCRIPTION
I found out that there is no option to specify default layout. If layout was set to true, layout name was set to 'layout'. This fix add an option to specify default template in 'view options'.

Example usage:
app.set("view options", { defaultLayout: 'layouts/default'});
